### PR TITLE
feat(memory): Implement /proc/meminfo parsing and memory usage display API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ Module.symvers
 Mkfile.old
 dkms.conf
 
-# Visual Studio Code Result Files
+# Ignore compiled binaries
 .vscode/
 main
+/build/

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+
+# Visual Studio Code Result Files
+.vscode/
+main

--- a/include/memory.h
+++ b/include/memory.h
@@ -1,0 +1,3 @@
+long GetTotMem(void);
+long GetAvailMem(void);
+double GetMemUsage(void);

--- a/src/memory.c
+++ b/src/memory.c
@@ -57,15 +57,33 @@ MemInfo *GetMemInfo(void)
 
 long GetTotMem(void)
 {
-    return 0;
+    MemInfo* temp = GetMemInfo();
+    if(temp == NULL)
+        return -1;
+
+    long totMem = temp->total_kb;
+    free(temp);
+    return totMem;
 }
 
 long GetAvailMem(void)
 {
-    return 0;
+    MemInfo* temp = GetMemInfo();
+    if(temp == NULL)
+        return -1;
+
+    long availMem = temp->available_kb;
+    free(temp);
+    return availMem;
 }
 
 double GetMemUsage(void)
 {
-    return 0.0;
+    MemInfo* temp = GetMemInfo();
+    if(temp == NULL)
+        return -1;
+
+    double usage = temp->usage;
+    free(temp);
+    return usage;
 }

--- a/src/memory.c
+++ b/src/memory.c
@@ -1,0 +1,33 @@
+#include <stdio.h>
+
+typedef struct
+{
+    long total_kb;
+    long available_kb;
+    double usage; // 사용률(%)
+} MemInfo;
+
+MemInfo *GetMemInfo(void)
+{
+    return NULL;
+}
+
+long GetTotMem(void)
+{
+    return 0;
+}
+
+long GetAvailMem(void)
+{
+    return 0;
+}
+
+double GetMemUsage(void)
+{
+    return 0.0;
+}
+
+double CalMemUsage(void)
+{
+    return 0.0;
+}

--- a/src/memory.c
+++ b/src/memory.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdlib.h>
 
 typedef struct
 {
@@ -9,7 +10,40 @@ typedef struct
 
 MemInfo *GetMemInfo(void)
 {
-    return NULL;
+    MemInfo* memInfo = (MemInfo*)malloc(sizeof(MemInfo));
+    if (memInfo == NULL)
+    {
+        perror("malloc");
+        return NULL;
+    }
+    memInfo->total_kb = 0;
+    memInfo->available_kb = 0;
+    memInfo->usage = 0.0;
+
+    FILE *fp = NULL;
+
+	fp = fopen("/proc/meminfo", "r");
+	if (fp == NULL)
+	{
+		perror("fopen");
+        free(memInfo);
+		return NULL;
+	}
+
+	char line[256] = {0};
+	while (fgets(line, sizeof(line), fp) != NULL)
+	{
+		if (memInfo->total_kb != 0 && memInfo->available_kb != 0)
+			break;
+
+		if(memInfo->total_kb == 0)
+			sscanf(line, "MemTotal: %8ld kB", &memInfo->total_kb);
+		if(memInfo->available_kb == 0)
+			sscanf(line, "MemAvailable: %12ld kB", &memInfo->available_kb);
+	}
+
+	fclose(fp);
+    return memInfo;
 }
 
 long GetTotMem(void)

--- a/src/memory.c
+++ b/src/memory.c
@@ -10,7 +10,7 @@ typedef struct
 
 MemInfo *GetMemInfo(void)
 {
-    MemInfo* memInfo = (MemInfo*)malloc(sizeof(MemInfo));
+    MemInfo *memInfo = (MemInfo *)malloc(sizeof(MemInfo));
     if (memInfo == NULL)
     {
         perror("malloc");
@@ -22,27 +22,36 @@ MemInfo *GetMemInfo(void)
 
     FILE *fp = NULL;
 
-	fp = fopen("/proc/meminfo", "r");
-	if (fp == NULL)
-	{
-		perror("fopen");
+    fp = fopen("/proc/meminfo", "r");
+    if (fp == NULL)
+    {
+        perror("fopen");
         free(memInfo);
-		return NULL;
-	}
+        return NULL;
+    }
 
-	char line[256] = {0};
-	while (fgets(line, sizeof(line), fp) != NULL)
-	{
-		if (memInfo->total_kb != 0 && memInfo->available_kb != 0)
-			break;
+    char line[256] = {0};
+    while (fgets(line, sizeof(line), fp) != NULL)
+    {
+        if (memInfo->total_kb != 0 && memInfo->available_kb != 0)
+            break;
 
-		if(memInfo->total_kb == 0)
-			sscanf(line, "MemTotal: %8ld kB", &memInfo->total_kb);
-		if(memInfo->available_kb == 0)
-			sscanf(line, "MemAvailable: %12ld kB", &memInfo->available_kb);
-	}
+        if (memInfo->total_kb == 0)
+            sscanf(line, "MemTotal: %8ld kB", &memInfo->total_kb);
+        if (memInfo->available_kb == 0)
+            sscanf(line, "MemAvailable: %12ld kB", &memInfo->available_kb);
+    }
 
-	fclose(fp);
+    fclose(fp);
+
+    if (memInfo->available_kb != 0 && memInfo->total_kb != 0)
+        memInfo->usage = 100 * (1 - (double)memInfo->available_kb / memInfo->total_kb);
+    else
+    {
+        free(memInfo);
+        memInfo = NULL;
+    }
+
     return memInfo;
 }
 
@@ -57,11 +66,6 @@ long GetAvailMem(void)
 }
 
 double GetMemUsage(void)
-{
-    return 0.0;
-}
-
-double CalMemUsage(void)
 {
     return 0.0;
 }


### PR DESCRIPTION
This PR adds a memory information module that parses `/proc/meminfo` 
to extract MemTotal and MemAvailable values. Also includes:

- GetTotMem, GetAvailMem, GetMemUsage APIs
- memory.h interface declaration
- validation logic and internal memory usage calculation